### PR TITLE
Code cleanup

### DIFF
--- a/Decorators/CacheKeyStrategyInterface.php
+++ b/Decorators/CacheKeyStrategyInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ScayTrase\Api\Rpc\Decorators;
+
+use ScayTrase\Api\Rpc\RpcRequestInterface;
+
+interface CacheKeyStrategyInterface
+{
+    /**
+     * Create cache key for given RPC
+     *
+     * @param RpcRequestInterface $request
+     *
+     * @return string
+     */
+    public function getKey(RpcRequestInterface $request);
+}

--- a/Decorators/CacheableResponseCollection.php
+++ b/Decorators/CacheableResponseCollection.php
@@ -11,8 +11,8 @@ final class CacheableResponseCollection implements \IteratorAggregate, ResponseC
 {
     /** @var  CacheItemPoolInterface */
     private $cache;
-    /** @var  RequestKeyExtractor */
-    private $extractor;
+    /** @var  CacheKeyStrategyInterface */
+    private $keyStrategy;
     /** @var  array */
     private $items;
     /** @var  ResponseCollectionInterface */
@@ -24,29 +24,29 @@ final class CacheableResponseCollection implements \IteratorAggregate, ResponseC
      * CacheableResponseCollection constructor.
      *
      * @param CacheItemPoolInterface      $cache
-     * @param RequestKeyExtractor         $extractor
+     * @param CacheKeyStrategyInterface   $keyStrategy
      * @param array                       $items
      * @param ResponseCollectionInterface $proxiedCollection
+     * @param int|null                    $ttl
      */
     public function __construct(
         CacheItemPoolInterface $cache,
-        RequestKeyExtractor $extractor,
+        CacheKeyStrategyInterface $keyStrategy,
         array $items,
         ResponseCollectionInterface $proxiedCollection,
         $ttl
     ) {
         $this->cache             = $cache;
-        $this->extractor         = $extractor;
+        $this->keyStrategy       = $keyStrategy;
         $this->items             = $items;
         $this->proxiedCollection = $proxiedCollection;
         $this->ttl               = $ttl ?: null;
     }
 
-
     /** {@inheritdoc} */
     public function getResponse(RpcRequestInterface $request)
     {
-        $key = $this->extractor->getKey($request);
+        $key = $this->keyStrategy->getKey($request);
 
         /** @var CacheItemInterface $item */
         $item = $this->items[$key]['item'];

--- a/Decorators/Sha1KeyStrategy.php
+++ b/Decorators/Sha1KeyStrategy.php
@@ -5,21 +5,20 @@ namespace ScayTrase\Api\Rpc\Decorators;
 use ScayTrase\Api\Rpc\RpcRequestInterface;
 
 /** @internal */
-class RequestKeyExtractor
+final class Sha1KeyStrategy implements CacheKeyStrategyInterface
 {
-    /** @var  string */
+    /** @var string */
     private $keyPrefix;
 
     /**
-     * RequestKeyExtractor constructor.
+     * Sha1KeyStrategy constructor.
      *
-     * @param $keyPrefix
+     * @param string $keyPrefix
      */
     public function __construct($keyPrefix)
     {
         $this->keyPrefix = $keyPrefix;
     }
-
 
     public function getKey(RpcRequestInterface $request)
     {

--- a/Tests/AbstractRpcTest.php
+++ b/Tests/AbstractRpcTest.php
@@ -2,87 +2,12 @@
 
 namespace ScayTrase\Api\Rpc\Tests;
 
-use Prophecy\Argument;
-use ScayTrase\Api\Rpc\ResponseCollectionInterface;
-use ScayTrase\Api\Rpc\RpcClientInterface;
-use ScayTrase\Api\Rpc\RpcErrorInterface;
-use ScayTrase\Api\Rpc\RpcRequestInterface;
-use ScayTrase\Api\Rpc\RpcResponseInterface;
+use PHPUnit\Framework\TestCase;
 
-abstract class AbstractRpcTest extends \PHPUnit_Framework_TestCase
+/**
+ * @deprecated use RpcRequestTrait instead to avoid inheritance lock
+ */
+abstract class AbstractRpcTest extends TestCase
 {
-    /**
-     * @param string $method
-     * @param array  $params
-     *
-     * @return RpcRequestInterface
-     */
-    protected function getRequestMock($method, array $params = [])
-    {
-        $request = $this->prophesize(RpcRequestInterface::class);
-        $request->getMethod()->willReturn($method);
-        $request->getParameters()->willReturn((object)$params);
-
-        return $request->reveal();
-    }
-
-    /**
-     * @param bool                       $success
-     * @param \stdClass|array|null|mixed $body
-     * @param RpcErrorInterface          $error
-     *
-     * @return RpcResponseInterface
-     */
-    protected function getResponseMock($success = true, $body = null, RpcErrorInterface $error = null)
-    {
-        $mock = $this->prophesize(RpcResponseInterface::class);
-        $mock->isSuccessful()->willReturn($success);
-        $mock->getError()->willReturn($success ? null : $error);
-        $mock->getBody()->willReturn($success ? $body : null);
-
-        return $mock->reveal();
-    }
-
-    /**
-     * @param mixed  $code
-     * @param string $message
-     *
-     * @return RpcErrorInterface
-     */
-    protected function getErrorMock($code, $message)
-    {
-        $mock = $this->prophesize(RpcErrorInterface::class);
-        $mock->getCode()->willReturn($code);
-        $mock->getMessage()->willReturn($message);
-
-        return $mock->reveal();
-    }
-
-    /**
-     * @param RpcRequestInterface[]  $requests
-     * @param RpcResponseInterface[] $responses
-     *
-     * @return RpcClientInterface
-     */
-    protected function getClientMock(array $requests = [], array $responses = [])
-    {
-        self::assertEquals(count($requests), count($responses));
-
-        $client = $this->prophesize(RpcClientInterface::class);
-        $that   = $this;
-        $client->invoke(Argument::type('array'))->will(
-            function ($args) use ($that, $requests, $responses) {
-                $collection = $that->prophesize(ResponseCollectionInterface::class);
-                foreach ($requests as $key => $request) {
-                    if (in_array($request, $args[0], true)) {
-                        $collection->getResponse(Argument::exact($request))->willReturn($responses[$key]);
-                    }
-                }
-
-                return $collection->reveal();
-            }
-        );
-
-        return $client->reveal();
-    }
+    use RpcRequestTrait;
 }

--- a/Tests/DecoratorTest.php
+++ b/Tests/DecoratorTest.php
@@ -2,6 +2,7 @@
 
 namespace ScayTrase\Api\Rpc\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
@@ -11,8 +12,10 @@ use ScayTrase\Api\Rpc\Decorators\CacheableRpcClient;
 use ScayTrase\Api\Rpc\Decorators\LoggableRpcClient;
 use ScayTrase\Api\Rpc\RpcRequestInterface;
 
-class DecoratorTest extends AbstractRpcTest
+final class DecoratorTest extends TestCase
 {
+    use RpcRequestTrait;
+
     public function testLoggableClient()
     {
         if (!interface_exists(LoggerInterface::class)) {

--- a/Tests/LazyClientTest.php
+++ b/Tests/LazyClientTest.php
@@ -2,12 +2,15 @@
 
 namespace ScayTrase\Api\Rpc\Tests;
 
+use PHPUnit\Framework\TestCase;
 use ScayTrase\Api\Rpc\Decorators\LazyRpcClient;
 use ScayTrase\Api\Rpc\RpcRequestInterface;
 use ScayTrase\Api\Rpc\RpcResponseInterface;
 
-class LazyClientTest extends AbstractRpcTest
+final class LazyClientTest extends TestCase
 {
+    use RpcRequestTrait;
+
     public function testLazyRequets()
     {
         $rq1 = $this->getRequestMock('/test1', ['param1' => 'test']);

--- a/Tests/RpcMockClientTest.php
+++ b/Tests/RpcMockClientTest.php
@@ -2,12 +2,15 @@
 
 namespace Scaytrase\Api\Rpc\Tests;
 
+use PHPUnit\Framework\TestCase;
 use ScayTrase\Api\Rpc\RpcRequestInterface;
 use ScayTrase\Api\Rpc\Test\MockClientException;
 use ScayTrase\Api\Rpc\Test\RpcMockClient;
 
-class RpcMockClientTest extends AbstractRpcTest
+final class RpcMockClientTest extends TestCase
 {
+    use RpcRequestTrait;
+
     public function testClientReturnsResponse()
     {
         $client = new RpcMockClient();

--- a/Tests/RpcRequestTrait.php
+++ b/Tests/RpcRequestTrait.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace ScayTrase\Api\Rpc\Tests;
+
+use Prophecy\Argument;
+use ScayTrase\Api\Rpc\ResponseCollectionInterface;
+use ScayTrase\Api\Rpc\RpcClientInterface;
+use ScayTrase\Api\Rpc\RpcErrorInterface;
+use ScayTrase\Api\Rpc\RpcRequestInterface;
+use ScayTrase\Api\Rpc\RpcResponseInterface;
+
+trait RpcRequestTrait
+{
+    /**
+     * @param string $method
+     * @param array  $params
+     *
+     * @return RpcRequestInterface
+     */
+    protected function getRequestMock($method, array $params = [])
+    {
+        $request = $this->prophesize(RpcRequestInterface::class);
+        $request->getMethod()->willReturn($method);
+        $request->getParameters()->willReturn((object)$params);
+
+        return $request->reveal();
+    }
+
+    /**
+     * @param bool                       $success
+     * @param \stdClass|array|null|mixed $body
+     * @param RpcErrorInterface          $error
+     *
+     * @return RpcResponseInterface
+     */
+    protected function getResponseMock($success = true, $body = null, RpcErrorInterface $error = null)
+    {
+        $mock = $this->prophesize(RpcResponseInterface::class);
+        $mock->isSuccessful()->willReturn($success);
+        $mock->getError()->willReturn($success ? null : $error);
+        $mock->getBody()->willReturn($success ? $body : null);
+
+        return $mock->reveal();
+    }
+
+    /**
+     * @param mixed  $code
+     * @param string $message
+     *
+     * @return RpcErrorInterface
+     */
+    protected function getErrorMock($code, $message)
+    {
+        $mock = $this->prophesize(RpcErrorInterface::class);
+        $mock->getCode()->willReturn($code);
+        $mock->getMessage()->willReturn($message);
+
+        return $mock->reveal();
+    }
+
+    /**
+     * @param RpcRequestInterface[]  $requests
+     * @param RpcResponseInterface[] $responses
+     *
+     * @return RpcClientInterface
+     */
+    protected function getClientMock(array $requests = [], array $responses = [])
+    {
+        self::assertEquals(count($requests), count($responses));
+
+        $client = $this->prophesize(RpcClientInterface::class);
+        $that   = $this;
+        $client->invoke(Argument::type('array'))->will(
+            function ($args) use ($that, $requests, $responses) {
+                $collection = $that->prophesize(ResponseCollectionInterface::class);
+                foreach ($requests as $key => $request) {
+                    if (in_array($request, $args[0], true)) {
+                        $collection->getResponse(Argument::exact($request))->willReturn($responses[$key]);
+                    }
+                }
+
+                return $collection->reveal();
+            }
+        );
+
+        return $client->reveal();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "php": "~5.5|~7.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.5|~5.1",
-    "paragonie/random_compat": "~1.1@stable",
+    "phpunit/phpunit": "^4.8.35 | ^5.1 | ^6.0",
+    "paragonie/random_compat": "^1|^2",
     "psr/cache": "~1.0",
     "psr/log": "~1.0"
   },


### PR DESCRIPTION
 * Finalize key extractors - cannot be extended anyway
 * Allow to replace key prefix with predefined key extractor
 * Extract AbstractRpcTest methods to trait to avoid inheritance
 * Deprecate AbstractRpcTest